### PR TITLE
fix deref undefined crash

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -260,7 +260,7 @@ const Home: NextPage = () => {
               loading={followLoading}
               className={styles.loadingButton}
             >
-              {!searchAddrInfo?.connections[0].followStatus.isFollowing
+              {!searchAddrInfo?.connections[0]?.followStatus.isFollowing
                 ? "Follow"
                 : "Unfollow"}
             </LoadingButton>


### PR DESCRIPTION
app crash when user tries to follow his own address. can be reproduced here https://cyberconnect-starter.vercel.app/
```
TypeError: Cannot read properties of undefined (reading 'followStatus')
    at W (index-89ee6a6e9d00e349.js:1:9743)
    at ro (framework-a58013ecf93b5e10.js:1:59434)
    at jo (framework-a58013ecf93b5e10.js:1:69001)
    at Hu (framework-a58013ecf93b5e10.js:1:112883)
    at Pi (framework-a58013ecf93b5e10.js:1:99066)
    at xi (framework-a58013ecf93b5e10.js:1:98994)
    at _i (framework-a58013ecf93b5e10.js:1:98857)
    at vi (framework-a58013ecf93b5e10.js:1:95823)
    at framework-a58013ecf93b5e10.js:1:45202
    at t.unstable_runWithPriority (framework-a58013ecf93b5e10.js:1:129507)
```